### PR TITLE
Java 7 compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
-# Unreleased
+## Unreleased
+### Changed
+* Changed HikariCP version to 2.4.13 Java 7 version for backward compatibility with older JVMs.
+
+## [0.0.1] 2017-12-12
 ### Added
 * Housekeeping module migrated from [circus-train](https://github.com/HotelsDotCom/circus-train) to this project

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,9 @@
     <!-- DataSource (HikariCP) -->
     <dependency>
       <groupId>com.zaxxer</groupId>
-      <artifactId>HikariCP</artifactId>
-      <version>2.4.3</version>
+      <artifactId>HikariCP-java7</artifactId>
+      <version>2.4.13</version>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Changed to use the Java 7 version of HikariCP as recommended at https://brettwooldridge.github.io/HikariCP/